### PR TITLE
Add missing `constructor` trait

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "MLJWrappers"
 uuid = "b5d0f7f3-9870-4c70-ba08-cb780c37e63f"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Anthony D. Blaom <anthony.blaom@gmail.com>"]
 
 [deps]

--- a/src/transformer.jl
+++ b/src/transformer.jl
@@ -42,6 +42,9 @@ MMI.metadata_pkg(
     is_wrapper = true
 )
 
+# wrappers are required to overload this trait:
+MMI.constructor(::Type{<:Transformer}) = Transformer
+
 MMI.metadata_model(
     Transformer,
     load_path = "Transformer.Transformer",

--- a/test/transformer.jl
+++ b/test/transformer.jl
@@ -26,6 +26,8 @@ end
 @test iteration_parameter(transformer) == :(model.n_trees)
 @test is_wrapper(transformer)
 
+@test MLJBase.MLJModelInterface.constructor(transformer) == Transformer
+
 # synthesize some data for training `model` and its wrapped version:
 rng = StableRNGs.StableRNG(123)
 x1 = rand(rng, 20)
@@ -60,7 +62,7 @@ importances = feature_importances(model, fitresult, rprt)
 importances2 = feature_importances(transformer, fitresult2, rprt2)
 @test importances2 == importances
 
-# not implemented by atomic model, so returning `nothing` here:
+# not implemented by atomic model, so  `nothing` is being returned here:
 @test training_losses(transformer, rprt2) == training_losses(model, rprt)
 
 # The `reducer` below is a supervised model implementing `transform`. For the above data,


### PR DESCRIPTION
Needed so that the package can be properly added to the  MLJ Model Registry.